### PR TITLE
feat: use explicit call instead of closure

### DIFF
--- a/src/did.rs
+++ b/src/did.rs
@@ -348,7 +348,7 @@ impl TryFrom<String> for Did {
     #[inline]
     #[expect(clippy::indexing_slicing, reason = "panic-safe indexing ensured")]
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let did_split: Vec<String> = value.splitn(4, ':').map(|x| x.to_owned()).collect();
+        let did_split: Vec<String> = value.splitn(4, ':').map(str::to_owned).collect();
         if did_split.len() < 4 {
             return Err(DidResolveError::MalformedDid(value));
         }


### PR DESCRIPTION
Since the input type is exactly known this could be seen as shorter and more concise since we don't really need the generality of the closure at all.
This could be a bit subjective (as which is 'better'), feel free to close if this is not seen as appropiate.