### PR TITLE
docs: fix typo in Did::get_url

### DIFF
--- a/src/did.rs
+++ b/src/did.rs
@@ -259,11 +259,11 @@ impl Did {
         self.scid.to_owned()
     }
 
-    /// Returns the HTTP URL [*transformed*](https://identity.foundation/didwebvh/next/#the-did-to-https-transformation)
+    /// Returns the HTTPS URL [*transformed*](https://identity.foundation/didwebvh/next/#the-did-to-https-transformation)
     /// from the DID supplied via constructor.
     ///
     /// A UniFFI-compliant method.
-    #[deprecated(since = "2.2.0", note = "please use `get_http_url` instead")]
+    #[deprecated(since = "2.2.0", note = "please use `get_https_url` instead")]
     #[inline]
     pub fn get_url(&self) -> Result<String, DidResolveError> {
         Ok(self.get_https_url())


### PR DESCRIPTION
`get_http_url` has been mistaken instead of `get_https_url`, as we don't have that function.
Also changed `HTTP` to `HTTPS` to be more inline with the `get_https_url` doc.