### PR TITLE
Add embed-debug feature, to allow library integration

### DIFF
--- a/did/Cargo.toml
+++ b/did/Cargo.toml
@@ -51,6 +51,7 @@ name = "uniffi-bindgen-swift"
 path = "uniffi-bindgen-swift.rs"
 
 [features]
+default = ["debug-embed"]
 ffi-trace = ["uniffi/ffi-trace"]
 debug-embed = ["did_tdw/debug-embed", "did_webvh/debug-embed"]
 

--- a/did/Cargo.toml
+++ b/did/Cargo.toml
@@ -52,6 +52,7 @@ path = "uniffi-bindgen-swift.rs"
 
 [features]
 ffi-trace = ["uniffi/ffi-trace"]
+debug-embed = ["did_tdw/debug-embed", "did_webvh/debug-embed"]
 
 # See [workspace.lints.clippy] in ../Cargo.toml
 # (w.r.t. https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table)

--- a/did_tdw/Cargo.toml
+++ b/did_tdw/Cargo.toml
@@ -38,6 +38,7 @@ rayon.workspace = true
 lazy_static.workspace = true
 
 [features]
+default = ["debug-embed"]
 debug-embed = ["rust-embed/debug-embed"]
 
 [build-dependencies]

--- a/did_tdw/Cargo.toml
+++ b/did_tdw/Cargo.toml
@@ -37,6 +37,9 @@ rust-embed = { workspace = true , features = ["include-exclude"]}
 rayon.workspace = true
 lazy_static.workspace = true
 
+[features]
+debug-embed = ["rust-embed/debug-embed"]
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 

--- a/did_webvh/Cargo.toml
+++ b/did_webvh/Cargo.toml
@@ -38,6 +38,7 @@ rayon.workspace = true
 lazy_static.workspace = true
 
 [features]
+default = ["debug-embed"]
 debug-embed = ["rust-embed/debug-embed"]
 
 [build-dependencies]

--- a/did_webvh/Cargo.toml
+++ b/did_webvh/Cargo.toml
@@ -37,6 +37,9 @@ rust-embed = { workspace = true , features = ["include-exclude"]}
 rayon.workspace = true
 lazy_static.workspace = true
 
+[features]
+debug-embed = ["rust-embed/debug-embed"]
+
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
 


### PR DESCRIPTION
Rust embed, used to include json-schemas, has the following property:

> In debug and when debug-embed feature is not enabled, the folder path is resolved relative to where the binary is run from.

Although this is nice for applications, it hinders the library to be used as a debug build with uniffi. This is especially a problem, when integrating the didresolver as a rust dependency (and then using uniffi).

This PR exposes the `debug-embed` feature as feature for the `did` crate, so as to release the requirement of adding the rust-embed crate as a direct dependency. 