### PR TITLE
Harden snyk-scanner workflow: pin actions to SHAs, least privilege, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Keeps the SHA-pinned GitHub Actions current via reviewed PRs.
+# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/snyk-scanner.yml
+++ b/.github/workflows/snyk-scanner.yml
@@ -27,7 +27,7 @@ permissions:
   # Require writing security events to upload SARIF file to security tab
   security-events: write
   # to fetch code (actions/checkout)
-  contents: write
+  contents: read
 
 env:
   SARIF_FILE: 
@@ -37,11 +37,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
-      - uses: psastras/sbom-rs/actions/install-cargo-sbom@cargo-sbom-v0.10.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: psastras/sbom-rs/actions/install-cargo-sbom@9ecc460b937ac5558c4f8ebebc9e07d2bdbef67b # cargo-sbom-v0.10.0
       - name: Generate sbom
         run: cargo-sbom  > didresolver.spdx.json
-      - uses: snyk/actions/setup@master
+      - uses: snyk/actions/setup@9cf6ca713d71123d2d229cc3d7f145b96ea3c518 # master
       - name: Snyk monitor 
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
           	exit -1
           fi
       - name: Upload code analysis results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
         with:
           sarif_file: didresolver.sarif
           category: snyk


### PR DESCRIPTION
**Supply-chain hardening.** Pins the actions in `snyk-scanner.yml` to full commit SHAs (with version comments), applies least-privilege `permissions`, and adds/extends `.github/dependabot.yml` with the `github-actions` ecosystem so pins stay current.

---
**Notes**
- Snyk steps need maintainer-side `SNYK_TOKEN`/`SNYK_ORG` secrets; fork-PR CI runs only after a maintainer clicks *Approve and run*.
- DCO: commit signed off by Daniel Casota.